### PR TITLE
Add CI/CD pipeline via GitHub Actions

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -1,0 +1,54 @@
+name: Anchore
+
+on: [push, pull_request]
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM with Syft
+        uses: anchore/sbom-action@v0.18.0
+        with:
+          # scanne tout le repo
+          path: .
+          # format JSON (SPDX)
+          format: spdx-json
+          # nom de l’artifact
+          artifact-name: sbom.spdx.json
+          upload-artifact: true
+  scan-sbom:
+    name: SCA Scan (Grype)
+    runs-on: ubuntu-latest
+    needs: generate-sbom
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom.spdx.json
+          path: .
+
+      - name: Scan SBOM with Grype
+        uses: anchore/scan-action@v6.1.0
+        id: sbom_scan
+        with:
+          # pointage sur le SBOM généré
+          sbom: ./sbom.spdx.json
+          # format de sortie JSON
+          output-format: json
+          # écriture du rapport dans ce fichier
+          output-file: sca-report.json
+          # ne pas échouer en cas de vulnérabilités
+          fail-build: false
+
+      - name: Upload SCA report
+        uses: actions/upload-artifact@v4
+        with:
+          name: sca-report.json
+          path: sca-report.json

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8","3.9","3.10" ]
+        python-version: [ "3.9" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,25 @@
+name: Bandit SAST
+
+on: [push, pull_request]
+
+jobs:
+  sast:
+    name: Static Security Scan (Bandit)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8","3.9","3.10" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Bandit
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+      - name: Run Bandit SAST scan
+        run: |
+          # recurse through code, exclude test dirs, only report high‑severity issues
+          bandit -r . --exclude unit_tests,integration_tests --severity-level high

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker Build & Push & Scan
+
+on: [push]
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker image
+    runs-on: ubuntu-latest
+    # Ne se lance que sur la branche dev
+    if: github.ref == 'refs/heads/dev'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/isen-python:dev-${{ github.sha }}
+
+  scan-container:
+    name: Trivy
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.3
+
+      - name: Scan Docker image
+        run: |
+          trivy image \
+            --format table \
+            --severity HIGH,CRITICAL \
+            ${{ secrets.DOCKERHUB_USERNAME }}/isen-python:dev-${{ github.sha }}
+        continue-on-error: true

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,16 @@
+name: Hadolint
+
+on: [push]
+
+jobs:
+  lint-docker:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Dockerfile with Hadolint (v3)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          args: --ignore DL3008

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: [ "3.9" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,27 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  lint-python:
+    name: Lint Python
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pylint
+
+      - name: Run Pylint
+        run: |
+          pylint --disable=C,R0801 --fail-under=7 $(git ls-files '*.py')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,52 @@
+name: Pytest
+
+on: [push, pull_request]
+
+jobs:
+  test-unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run Pytest on unit_tests
+        run: |
+          pytest --maxfail=1 --disable-warnings -q unit_tests/
+
+  test-integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest pytest-django
+
+      - name: Run Pytest on integration_tests
+        run: |
+          pytest --maxfail=1 --disable-warnings -q integration_tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: [ "3.9" ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: [ "3.9" ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Création d’un groupe et d’un utilisateur système non‑root
+RUN addgroup --system appuser \
+ && adduser  --system --ingroup appuser appuser
+
+# Passe à cet utilisateur pour l’exécution
+USER appuser
+
 EXPOSE 8000
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8080"]


### PR DESCRIPTION
# Pull Request: Add GitHub Actions CI/CD workflows

**From:** `dev`  
**Into:** `main`

## Description

This PR implements the full CI/CD pipeline tracked by Issue #1:

- **Linting**  
  - Python files with **Pylint** (`.github/workflows/pylint.yml` — fail under 7, disables C,R0801)  
  - Dockerfile with **Hadolint** (`.github/workflows/hadolint.yml` — ignores DL3008)  

- **Testing**  
  - **Unit tests** (`.github/workflows/pytest.yml` → `unit_tests/`)  
  - **Integration tests** (`.github/workflows/pytest.yml` → `integration_tests/`)  

- **Security scans**  
  - Static App Sec with **Bandit** (`.github/workflows/bandit.yml` — high severity only)  
  - Container vulnerability scan with **Trivy** (`.github/workflows/docker.yml` — HIGH/CRITICAL, `continue-on-error`)  

- **Build & publish**  
  - Docker image **build & push** to Docker Hub (`.github/workflows/docker.yml` — tag `isen-python:dev-${{ github.sha }}`)  

- **SBOM & SCA**  
  - **SBOM generation** with Syft (`.github/workflows/anchore.yml`)  
  - **SBOM scan** with Grype (`.github/workflows/anchore.yml`)

Each workflow triggers on `push` (and on `pull_request` where applicable) and runs on GitHub-hosted Ubuntu runners. Docker Hub credentials must be set in repo **Secrets** as `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.

## Files Added

```diff
 .github/workflows/
+ anchore.yml
+ bandit.yml
+ docker.yml
+ hadolint.yml
+ pylint.yml
+ pytest.yml
